### PR TITLE
Add use strict declaration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict';
 const Promise = require('bluebird');
 const cloudinary = require('cloudinary');
 const path = require('path')
@@ -16,33 +17,33 @@ class Store extends BaseStore {
         this.config = config || {}
         cloudinary.config(config);
     }
-    
+
     save(image) {
         const secure = this.config.secure || false;
-        
+
         return new Promise(function(resolve) {
             cloudinary.uploader.upload(image.path, function(result) {
                 resolve(secure ? result.secure_url : result.url);
             });
         });
     }
-    
+
     serve() {
         return function(req, res, next) {
             next();
         };
     }
-    
+
     read() {
-    
+
     }
-    
+
     delete() {
-    
+
     }
-    
+
     exists() {
-    
+
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -8,5 +8,10 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kandros/ghost-cloudinary-storage.git"
+  },
+  "dependencies": {
+    "bluebird": "^2.10.0",
+    "cloudinary": "^1.2.0",
+    "path": "^0.12.7"
   }
 }


### PR DESCRIPTION
I'm encountering the `Block-scoped declarations (let, const, function, class) not yet supported outside strict mode` error while using `ghost:0.11.9` Docker image, so I added the use strict declaration.

Also added the missing dependencies